### PR TITLE
Windows compilation fixes + fix improper uses of FindNextFile API.

### DIFF
--- a/include/all/sfz/os.hpp
+++ b/include/all/sfz/os.hpp
@@ -39,9 +39,15 @@ void       chdir(pn::string_view path);
 pn::string getcwd();
 void       symlink(pn::string_view content, pn::string_view container);
 
-void mkdir(pn::string_view path, mode_t mode);
-void mkfifo(pn::string_view path, mode_t mode);
-void makedirs(pn::string_view path, mode_t mode);
+#ifdef _MSC_VER
+typedef int mkdir_mode_t;
+#else
+typedef mode_t mkdir_mode_t;
+#endif
+
+void mkdir(pn::string_view path, mkdir_mode_t mode);
+void mkfifo(pn::string_view path, mkdir_mode_t mode);
+void makedirs(pn::string_view path, mkdir_mode_t mode);
 
 void unlink(pn::string_view path);
 void rmdir(pn::string_view path);

--- a/include/win/sfz/file.hpp
+++ b/include/win/sfz/file.hpp
@@ -6,7 +6,17 @@
 #ifndef SFZ_FILE_HPP_
 #define SFZ_FILE_HPP_
 
-#include <fileapi.h>
+#pragma push_macro("WIN32_LEAN_AND_MEAN")
+#pragma push_macro("NOMINMAX")
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+
+#pragma pop_macro("WIN32_LEAN_AND_MEAN")
+#pragma pop_macro("NOMINMAX")
+
+
 #include <pn/data>
 #include <pn/string>
 

--- a/src/win/sfz/file.cpp
+++ b/src/win/sfz/file.cpp
@@ -11,7 +11,6 @@
 #include <fcntl.h>
 #include <memoryapi.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <pn/output>
 #include <sfz/error.hpp>
 #include <stdexcept>


### PR DESCRIPTION
Replaces mode_t dependency and removes some includes to fix compilation in VS.
Fixes several improper uses of FindNextFile API where it was either expecting 0 to be returned on failure instead of INVALID_HANDLE_VALUE, and was calling CloseHandle (which is the wrong call and triggers an exception) to clean up instead of FindClose.