### PR TITLE
Fix missing parameter name

### DIFF
--- a/src/all/sfz/digest.cpp
+++ b/src/all/sfz/digest.cpp
@@ -220,7 +220,7 @@ sha1::digest tree_digest(pn::string_view path) {
         }
 
         // Can't happen during WALK_LOGICAL.
-        void symlink(pn::string_view path, const Stat&) const {
+        void symlink(pn::string_view path, const Stat& stat) const {
             static_cast<void>(path);
             static_cast<void>(stat);
         }


### PR DESCRIPTION
Fixes "function call missing argument list" warning.
"stat" was resolving to the global function "stat" instead of the parameter.