### PR TITLE
Use the wrong capitalization for Windows.h to make cross-compile happy

### DIFF
--- a/include/win/sfz/file.hpp
+++ b/include/win/sfz/file.hpp
@@ -11,7 +11,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 
 #pragma pop_macro("WIN32_LEAN_AND_MEAN")
 #pragma pop_macro("NOMINMAX")


### PR DESCRIPTION
Sigh.